### PR TITLE
Split code into smaller files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FORK OF wgsl_ln, for adding my personal improvements
+# wgsl_ln
 
 [![Crates.io](https://img.shields.io/crates/v/wgsl_ln.svg)](https://crates.io/crates/wgsl_ln)
 [![Docs](https://docs.rs/wgsl_ln/badge.svg)](https://docs.rs/wgsl_ln/latest/wgsl_ln/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wgsl_ln
+#FORK OF wgsl_ln, for adding my personal improvements
 
 [![Crates.io](https://img.shields.io/crates/v/wgsl_ln.svg)](https://crates.io/crates/wgsl_ln)
 [![Docs](https://docs.rs/wgsl_ln/badge.svg)](https://docs.rs/wgsl_ln/latest/wgsl_ln/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#FORK OF wgsl_ln, for adding my personal improvements
+# FORK OF wgsl_ln, for adding my personal improvements
 
 [![Crates.io](https://img.shields.io/crates/v/wgsl_ln.svg)](https://crates.io/crates/wgsl_ln)
 [![Docs](https://docs.rs/wgsl_ln/badge.svg)](https://docs.rs/wgsl_ln/latest/wgsl_ln/)

--- a/src/__wgsl_paste2.rs
+++ b/src/__wgsl_paste2.rs
@@ -1,0 +1,52 @@
+use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
+use proc_macro_error::abort;
+use quote::quote;
+pub fn __wgsl_paste2(stream: TokenStream) -> TokenStream {
+    let mut iter = stream.into_iter();
+    let Some(TokenTree::Ident(definition)) = iter.next() else {
+        abort!(
+            Span::call_site(),
+            "Expected `__wgsl_paste!($definition {to_be_pasted} $([$($defined)*])? $($tt)*)`!"
+        )
+    };
+    let Some(TokenTree::Group(pasted)) = iter.next() else {
+        abort!(
+            Span::call_site(),
+            "Expected `__wgsl_paste!($definition {to_be_pasted} $([$($defined)*])? $($tt)*)`!"
+        )
+    };
+    let pasted = pasted.stream();
+    match iter.next() {
+        // If some values are defined, check if this item has been defined.
+        // If defined, skip, if not defined, paste and define this item.
+        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
+            let tokens: TokenStream = iter.collect();
+            let mut found = false;
+            let names: Vec<_> = g
+                .stream()
+                .into_iter()
+                .filter(|x| match x {
+                    TokenTree::Ident(i) => {
+                        if i == &definition {
+                            found = true;
+                        }
+                        true
+                    }
+                    _ => false,
+                })
+                .collect();
+            if found {
+                quote!(::wgsl_ln::wgsl!([#(#names)*] #tokens))
+            } else {
+                quote!(::wgsl_ln::wgsl!([#(#names)* #definition] #pasted #tokens))
+            }
+        }
+        // If no values defined, paste and define this item.
+        other => {
+            let tokens: TokenStream = iter.collect();
+            quote! {
+                ::wgsl_ln::wgsl!([#definition] #pasted #other #tokens)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,14 @@
 //! * Checks will be disabled when naga_oil preprocessor macros are detected.
 //!
 
-use naga::valid::{Capabilities, ValidationFlags, Validator};
 use proc_macro::TokenStream as TokenStream1;
-use proc_macro2::{
-    token_stream::IntoIter, Delimiter, Group, Ident, Spacing, Span, TokenStream, TokenTree,
-};
-use proc_macro_error::{abort, proc_macro_error};
-use quote::{format_ident, quote};
+use proc_macro_error::proc_macro_error;
+mod __wgsl_paste2;
+mod open_close;
+mod sanitize;
+mod to_wgsl_string;
+mod wgsl2;
+mod wgsl_export2;
 
 /// Converts normal rust tokens into a wgsl `&'static str`, similar to [`stringify!`].
 /// This also validates the wgsl string using [`naga`]. Errors will be reported with
@@ -163,237 +164,7 @@ use quote::{format_ident, quote};
 #[proc_macro]
 #[proc_macro_error]
 pub fn wgsl(stream: TokenStream1) -> TokenStream1 {
-    wgsl2(stream.into()).into()
-}
-
-fn open(d: Delimiter) -> char {
-    match d {
-        Delimiter::Parenthesis => '(',
-        Delimiter::Brace => '{',
-        Delimiter::Bracket => '[',
-        Delimiter::None => ' ',
-    }
-}
-
-fn close(d: Delimiter) -> char {
-    match d {
-        Delimiter::Parenthesis => ')',
-        Delimiter::Brace => '}',
-        Delimiter::Bracket => ']',
-        Delimiter::None => ' ',
-    }
-}
-
-/// Convert to `wgsl` and return if we think this uses `naga_oil` or not.
-/// This has to format in a certain way to make `naga_oil` work:
-///
-/// * Linebreaks after `;` and `}`.
-/// * Linebreaks before `#`.
-/// * No space after `#`.
-/// * No spaces before and after `:`.
-fn to_wgsl_string(
-    stream: TokenStream,
-    spans: &mut Vec<(usize, Span)>,
-    string: &mut String,
-) -> bool {
-    let mut first = true;
-    let mut uses_naga_oil = false;
-    for token in stream {
-        match token {
-            TokenTree::Group(g) if first && g.delimiter() == Delimiter::Bracket => (),
-            TokenTree::Ident(i) => {
-                spans.push((string.len(), i.span()));
-                string.push_str(&i.to_string());
-                string.push(' ');
-            }
-            TokenTree::Punct(p) => {
-                spans.push((string.len(), p.span()));
-                if p.as_char() == ';' {
-                    string.push(p.as_char());
-                    string.push('\n');
-                } else if p.as_char() == '#' {
-                    // new line and no spaces for naga_oil
-                    string.push('\n');
-                    string.push(p.as_char());
-                    uses_naga_oil = true;
-                } else if p.as_char() == ':' {
-                    // bend over backwards for `naga_oil` :p
-                    match string.pop() {
-                        Some(' ') => (),
-                        Some(c) => string.push(c),
-                        None => (),
-                    }
-                    string.push(p.as_char());
-                    uses_naga_oil = true;
-                } else if p.spacing() == Spacing::Alone {
-                    string.push(p.as_char());
-                    string.push(' ');
-                } else {
-                    string.push(p.as_char());
-                }
-            }
-            TokenTree::Literal(l) => {
-                spans.push((string.len(), l.span()));
-                string.push_str(&l.to_string());
-                string.push(' ');
-            }
-            TokenTree::Group(g) => {
-                spans.push((string.len(), g.delim_span().open()));
-                string.push(open(g.delimiter()));
-                if g.delimiter() == Delimiter::Brace {
-                    string.push('\n')
-                }
-                uses_naga_oil |= to_wgsl_string(g.stream(), spans, string);
-                spans.push((string.len(), g.delim_span().close()));
-                string.push(close(g.delimiter()));
-                if g.delimiter() == Delimiter::Brace {
-                    string.push('\n')
-                }
-            }
-        }
-        first = false;
-    }
-    uses_naga_oil
-}
-
-/// Remove duplicated `#`s from `# ident`s.
-fn sanitize_remaining(stream: IntoIter, ident: &Ident, items: &mut Vec<TokenTree>) {
-    let mut last_is_hash = false;
-    for tt in stream {
-        match &tt {
-            // ifndef
-            TokenTree::Punct(p) if p.as_char() == '#' => {
-                last_is_hash = true;
-                items.push(tt)
-            }
-            TokenTree::Ident(i) if last_is_hash && i == ident => {
-                last_is_hash = false;
-                let _ = items.pop();
-                items.push(tt)
-            }
-            TokenTree::Group(g) => {
-                last_is_hash = false;
-                let mut stream = Vec::new();
-                sanitize_remaining(g.stream().into_iter(), ident, &mut stream);
-                items.push(TokenTree::Group(Group::new(
-                    g.delimiter(),
-                    TokenStream::from_iter(stream),
-                )))
-            }
-            _ => {
-                last_is_hash = false;
-                items.push(tt)
-            }
-        }
-    }
-}
-
-fn is_naga_oil_name(name: &Ident) -> bool {
-    name == "define_import_path"
-        || name == "import"
-        || name == "if"
-        || name == "ifdef"
-        || name == "ifndef"
-        || name == "else"
-        || name == "endif"
-}
-
-/// Find the first instance of `#ident` and rewrite the macro as `__paste!(wgsl!())`.
-fn sanitize(stream: TokenStream) -> (TokenStream, Option<Ident>) {
-    let mut result = Vec::new();
-    let mut last_is_hash = false;
-    let mut iter = stream.into_iter();
-    let mut first = true;
-    while let Some(tt) = iter.next() {
-        match tt {
-            // ifndef
-            TokenTree::Group(g) if first && g.delimiter() == Delimiter::Bracket => {
-                result.push(TokenTree::Group(g));
-            }
-            TokenTree::Punct(p) if p.as_char() == '#' => {
-                last_is_hash = true;
-            }
-            // if is a naga_oil definition, write `#def`
-            #[cfg(feature = "naga_oil")]
-            TokenTree::Ident(ident) if last_is_hash && is_naga_oil_name(&ident) => {
-                last_is_hash = false;
-                result.push(TokenTree::Punct(proc_macro2::Punct::new(
-                    '#',
-                    Spacing::Joint,
-                )));
-                result.push(TokenTree::Ident(ident.clone()));
-            }
-            // If # ident, import it and remove duplicated `#`s.
-            TokenTree::Ident(ident) if last_is_hash => {
-                result.push(TokenTree::Ident(ident.clone()));
-                sanitize_remaining(iter, &ident, &mut result);
-                return (TokenStream::from_iter(result), Some(ident));
-            }
-            // Recursively look for `#`s.
-            TokenTree::Group(g) => {
-                let delim = g.delimiter();
-                let (stream, ident) = sanitize(g.stream());
-                result.push(TokenTree::Group(Group::new(delim, stream)));
-                if let Some(ident) = ident {
-                    sanitize_remaining(iter, &ident, &mut result);
-                    return (TokenStream::from_iter(result), Some(ident));
-                }
-            }
-            tt => {
-                last_is_hash = false;
-                result.push(tt)
-            }
-        }
-        first = false
-    }
-    (TokenStream::from_iter(result), None)
-}
-
-fn wgsl2(stream: TokenStream) -> TokenStream {
-    let (stream, pastes) = sanitize(stream);
-    if let Some(paste) = pastes {
-        let paste = format_ident!("__wgsl_paste_{}", paste);
-        return quote! {{use crate::*; #paste!(wgsl!(#stream))}};
-    }
-    let mut spans = Vec::new();
-    let mut source = String::new();
-    #[allow(unused_variables)]
-    let uses_naga_oil = to_wgsl_string(stream, &mut spans, &mut source);
-    #[cfg(feature = "naga_oil")]
-    if uses_naga_oil {
-        return quote! {#source};
-    }
-    match naga::front::wgsl::parse_str(&source) {
-        Ok(module) => {
-            match Validator::new(ValidationFlags::all(), Capabilities::all()).validate(&module) {
-                Ok(_) => quote! {#source},
-                Err(e) => {
-                    if let Some((span, _)) = e.spans().next() {
-                        let location = span.location(&source);
-                        let pos = match spans.binary_search_by_key(&(location.offset as usize), |x| x.0) {
-                            Ok(x) => x,
-                            Err(x) => x.saturating_sub(1),
-                        };
-                        abort!(spans[pos].1, "Wgsl Error: {}", e)
-                    }
-                    let e_str = e.to_string();
-                    quote! {compile_error!(#e_str)}
-                },
-            }
-        },
-        Err(e) => {
-            if let Some((span, _)) = e.labels().next() {
-                let location = span.location(&source);
-                let pos = match spans.binary_search_by_key(&(location.offset as usize), |x| x.0) {
-                    Ok(x) => x,
-                    Err(x) => x.saturating_sub(1),
-                };
-                abort!(spans[pos].1, "Wgsl Error: {}", e)
-            }
-            let e_str = e.to_string();
-            quote! {compile_error!(#e_str)}
-        }
-    }
+    wgsl2::wgsl2(stream.into()).into()
 }
 
 /// Export a wgsl item (function, struct, etc).
@@ -412,51 +183,7 @@ fn wgsl2(stream: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn wgsl_export(attr: TokenStream1, stream: TokenStream1) -> TokenStream1 {
-    wgsl_export2(attr.into(), stream.into()).into()
-}
-
-fn wgsl_export2(attr: TokenStream, stream: TokenStream) -> TokenStream {
-    let Some(TokenTree::Ident(name)) = attr.into_iter().next() else {
-        abort!(Span::call_site(), "Expected #[wgsl_export(name)]");
-    };
-    let mut wgsl_macro_ident = false;
-    let mut exclamation_mark = false;
-    let sealed = format_ident!("__sealed_{}", name);
-    let mut paste = format_ident!("__wgsl_paste_{}", name);
-    paste.set_span(name.span());
-    for token in stream.clone() {
-        match token {
-            TokenTree::Ident(i) if i == "wgsl" => {
-                wgsl_macro_ident = true;
-                exclamation_mark = false;
-            }
-            TokenTree::Punct(p) if wgsl_macro_ident && p.as_char() == '!' => {
-                exclamation_mark = true;
-            }
-            TokenTree::Group(g) if wgsl_macro_ident && exclamation_mark => {
-                let source = g.stream();
-                return quote! {
-                    #[allow(non_snake_case)]
-                    mod #sealed {
-                        #[allow(non_snake_case)]
-                        #[doc(hidden)]
-                        #[macro_export]
-                        macro_rules! #paste {
-                            (wgsl!($($tt: tt)*)) => {
-                                ::wgsl_ln::__wgsl_paste!(#name {#source} $($tt)*)
-                            };
-                        }
-                    }
-                    #stream
-                };
-            }
-            _ => {
-                wgsl_macro_ident = false;
-                exclamation_mark = false;
-            }
-        }
-    }
-    abort!(Span::call_site(), "Expected wgsl! macro.");
+    wgsl_export2::wgsl_export2(attr.into(), stream.into()).into()
 }
 
 /// Paste and avoid duplicates.
@@ -464,55 +191,5 @@ fn wgsl_export2(attr: TokenStream, stream: TokenStream) -> TokenStream {
 #[proc_macro]
 #[proc_macro_error]
 pub fn __wgsl_paste(stream: TokenStream1) -> TokenStream1 {
-    __wgsl_paste2(stream.into()).into()
-}
-
-fn __wgsl_paste2(stream: TokenStream) -> TokenStream {
-    let mut iter = stream.into_iter();
-    let Some(TokenTree::Ident(definition)) = iter.next() else {
-        abort!(
-            Span::call_site(),
-            "Expected `__wgsl_paste!($definition {to_be_pasted} $([$($defined)*])? $($tt)*)`!"
-        )
-    };
-    let Some(TokenTree::Group(pasted)) = iter.next() else {
-        abort!(
-            Span::call_site(),
-            "Expected `__wgsl_paste!($definition {to_be_pasted} $([$($defined)*])? $($tt)*)`!"
-        )
-    };
-    let pasted = pasted.stream();
-    match iter.next() {
-        // If some values are defined, check if this item has been defined.
-        // If defined, skip, if not defined, paste and define this item.
-        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Bracket => {
-            let tokens: TokenStream = iter.collect();
-            let mut found = false;
-            let names: Vec<_> = g
-                .stream()
-                .into_iter()
-                .filter(|x| match x {
-                    TokenTree::Ident(i) => {
-                        if i == &definition {
-                            found = true;
-                        }
-                        true
-                    }
-                    _ => false,
-                })
-                .collect();
-            if found {
-                quote!(::wgsl_ln::wgsl!([#(#names)*] #tokens))
-            } else {
-                quote!(::wgsl_ln::wgsl!([#(#names)* #definition] #pasted #tokens))
-            }
-        }
-        // If no values defined, paste and define this item.
-        other => {
-            let tokens: TokenStream = iter.collect();
-            quote! {
-                ::wgsl_ln::wgsl!([#definition] #pasted #other #tokens)
-            }
-        }
-    }
+    __wgsl_paste2::__wgsl_paste2(stream.into()).into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@
 //!
 
 use proc_macro::TokenStream as TokenStream1;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error::{proc_macro_error, set_dummy};
+use quote::quote;
 mod __wgsl_paste2;
 mod open_close;
 mod sanitize;
@@ -164,6 +165,7 @@ mod wgsl_export2;
 #[proc_macro]
 #[proc_macro_error]
 pub fn wgsl(stream: TokenStream1) -> TokenStream1 {
+    set_dummy(quote! {""});
     wgsl2::wgsl2(stream.into()).into()
 }
 
@@ -183,6 +185,8 @@ pub fn wgsl(stream: TokenStream1) -> TokenStream1 {
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn wgsl_export(attr: TokenStream1, stream: TokenStream1) -> TokenStream1 {
+    set_dummy(quote! {""});
+
     wgsl_export2::wgsl_export2(attr.into(), stream.into()).into()
 }
 
@@ -191,5 +195,7 @@ pub fn wgsl_export(attr: TokenStream1, stream: TokenStream1) -> TokenStream1 {
 #[proc_macro]
 #[proc_macro_error]
 pub fn __wgsl_paste(stream: TokenStream1) -> TokenStream1 {
+    set_dummy(quote! {""});
+
     __wgsl_paste2::__wgsl_paste2(stream.into()).into()
 }

--- a/src/open_close.rs
+++ b/src/open_close.rs
@@ -1,0 +1,19 @@
+use proc_macro2::Delimiter;
+
+pub fn open(d: Delimiter) -> char {
+    match d {
+        Delimiter::Parenthesis => '(',
+        Delimiter::Brace => '{',
+        Delimiter::Bracket => '[',
+        Delimiter::None => ' ',
+    }
+}
+
+pub fn close(d: Delimiter) -> char {
+    match d {
+        Delimiter::Parenthesis => ')',
+        Delimiter::Brace => '}',
+        Delimiter::Bracket => ']',
+        Delimiter::None => ' ',
+    }
+}

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,4 +1,7 @@
-use proc_macro2::{token_stream::IntoIter, Delimiter, Group, Ident, TokenStream, TokenTree};
+#[allow(unused)]
+use proc_macro2::{
+    token_stream::IntoIter, Delimiter, Group, Ident, Spacing, TokenStream, TokenTree,
+};
 /// Find the first instance of `#ident` and rewrite the macro as `__paste!(wgsl!())`.
 pub fn sanitize(stream: TokenStream) -> (TokenStream, Option<Ident>) {
     let mut result = Vec::new();

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,94 @@
+use proc_macro2::{token_stream::IntoIter, Delimiter, Group, Ident, TokenStream, TokenTree};
+/// Find the first instance of `#ident` and rewrite the macro as `__paste!(wgsl!())`.
+pub fn sanitize(stream: TokenStream) -> (TokenStream, Option<Ident>) {
+    let mut result = Vec::new();
+    let mut last_is_hash = false;
+    let mut iter = stream.into_iter();
+    let mut first = true;
+    while let Some(tt) = iter.next() {
+        match tt {
+            // ifndef
+            TokenTree::Group(g) if first && g.delimiter() == Delimiter::Bracket => {
+                result.push(TokenTree::Group(g));
+            }
+            TokenTree::Punct(p) if p.as_char() == '#' => {
+                last_is_hash = true;
+            }
+            // if is a naga_oil definition, write `#def`
+            #[cfg(feature = "naga_oil")]
+            TokenTree::Ident(ident) if last_is_hash && is_naga_oil_name(&ident) => {
+                last_is_hash = false;
+                result.push(TokenTree::Punct(proc_macro2::Punct::new(
+                    '#',
+                    Spacing::Joint,
+                )));
+                result.push(TokenTree::Ident(ident.clone()));
+            }
+            // If # ident, import it and remove duplicated `#`s.
+            TokenTree::Ident(ident) if last_is_hash => {
+                result.push(TokenTree::Ident(ident.clone()));
+                sanitize_remaining(iter, &ident, &mut result);
+                return (TokenStream::from_iter(result), Some(ident));
+            }
+            // Recursively look for `#`s.
+            TokenTree::Group(g) => {
+                let delim = g.delimiter();
+                let (stream, ident) = sanitize(g.stream());
+                result.push(TokenTree::Group(Group::new(delim, stream)));
+                if let Some(ident) = ident {
+                    sanitize_remaining(iter, &ident, &mut result);
+                    return (TokenStream::from_iter(result), Some(ident));
+                }
+            }
+            tt => {
+                last_is_hash = false;
+                result.push(tt)
+            }
+        }
+        first = false
+    }
+    (TokenStream::from_iter(result), None)
+}
+
+/// Remove duplicated `#`s from `# ident`s.
+pub fn sanitize_remaining(stream: IntoIter, ident: &Ident, items: &mut Vec<TokenTree>) {
+    let mut last_is_hash = false;
+    for tt in stream {
+        match &tt {
+            // ifndef
+            TokenTree::Punct(p) if p.as_char() == '#' => {
+                last_is_hash = true;
+                items.push(tt)
+            }
+            TokenTree::Ident(i) if last_is_hash && i == ident => {
+                last_is_hash = false;
+                let _ = items.pop();
+                items.push(tt)
+            }
+            TokenTree::Group(g) => {
+                last_is_hash = false;
+                let mut stream = Vec::new();
+                sanitize_remaining(g.stream().into_iter(), ident, &mut stream);
+                items.push(TokenTree::Group(Group::new(
+                    g.delimiter(),
+                    TokenStream::from_iter(stream),
+                )))
+            }
+            _ => {
+                last_is_hash = false;
+                items.push(tt)
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn is_naga_oil_name(name: &Ident) -> bool {
+    name == "define_import_path"
+        || name == "import"
+        || name == "if"
+        || name == "ifdef"
+        || name == "ifndef"
+        || name == "else"
+        || name == "endif"
+}

--- a/src/to_wgsl_string.rs
+++ b/src/to_wgsl_string.rs
@@ -1,0 +1,74 @@
+use proc_macro2::{Delimiter, Spacing, Span, TokenStream, TokenTree};
+
+use crate::open_close::{close, open};
+/// Convert to `wgsl` and return if we think this uses `naga_oil` or not.
+/// This has to format in a certain way to make `naga_oil` work:
+///
+/// * Linebreaks after `;` and `}`.
+/// * Linebreaks before `#`.
+/// * No space after `#`.
+/// * No spaces before and after `:`.
+pub fn to_wgsl_string(
+    stream: TokenStream,
+    spans: &mut Vec<(usize, Span)>,
+    string: &mut String,
+) -> bool {
+    let mut first = true;
+    let mut uses_naga_oil = false;
+    for token in stream {
+        match token {
+            TokenTree::Group(g) if first && g.delimiter() == Delimiter::Bracket => (),
+            TokenTree::Ident(i) => {
+                spans.push((string.len(), i.span()));
+                string.push_str(&i.to_string());
+                string.push(' ');
+            }
+            TokenTree::Punct(p) => {
+                spans.push((string.len(), p.span()));
+                if p.as_char() == ';' {
+                    string.push(p.as_char());
+                    string.push('\n');
+                } else if p.as_char() == '#' {
+                    // new line and no spaces for naga_oil
+                    string.push('\n');
+                    string.push(p.as_char());
+                    uses_naga_oil = true;
+                } else if p.as_char() == ':' {
+                    // bend over backwards for `naga_oil` :p
+                    match string.pop() {
+                        Some(' ') => (),
+                        Some(c) => string.push(c),
+                        None => (),
+                    }
+                    string.push(p.as_char());
+                    uses_naga_oil = true;
+                } else if p.spacing() == Spacing::Alone {
+                    string.push(p.as_char());
+                    string.push(' ');
+                } else {
+                    string.push(p.as_char());
+                }
+            }
+            TokenTree::Literal(l) => {
+                spans.push((string.len(), l.span()));
+                string.push_str(&l.to_string());
+                string.push(' ');
+            }
+            TokenTree::Group(g) => {
+                spans.push((string.len(), g.delim_span().open()));
+                string.push(open(g.delimiter()));
+                if g.delimiter() == Delimiter::Brace {
+                    string.push('\n')
+                }
+                uses_naga_oil |= to_wgsl_string(g.stream(), spans, string);
+                spans.push((string.len(), g.delim_span().close()));
+                string.push(close(g.delimiter()));
+                if g.delimiter() == Delimiter::Brace {
+                    string.push('\n')
+                }
+            }
+        }
+        first = false;
+    }
+    uses_naga_oil
+}

--- a/src/wgsl2.rs
+++ b/src/wgsl2.rs
@@ -1,0 +1,55 @@
+use naga::valid::{Capabilities, ValidationFlags, Validator};
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::{format_ident, quote};
+
+use crate::{sanitize::sanitize, to_wgsl_string::to_wgsl_string};
+
+pub fn wgsl2(stream: TokenStream) -> TokenStream {
+    let (stream, pastes) = sanitize(stream);
+    if let Some(paste) = pastes {
+        let paste = format_ident!("__wgsl_paste_{}", paste);
+        return quote! {{use crate::*; #paste!(wgsl!(#stream))}};
+    }
+    let mut spans = Vec::new();
+    let mut source = String::new();
+    #[allow(unused_variables)]
+    let uses_naga_oil = to_wgsl_string(stream, &mut spans, &mut source);
+    #[cfg(feature = "naga_oil")]
+    if uses_naga_oil {
+        return quote! {#source};
+    }
+    match naga::front::wgsl::parse_str(&source) {
+        Ok(module) => {
+            match Validator::new(ValidationFlags::all(), Capabilities::all()).validate(&module) {
+                Ok(_) => quote! {#source},
+                Err(e) => {
+                    if let Some((span, _)) = e.spans().next() {
+                        let location = span.location(&source);
+                        let pos = match spans
+                            .binary_search_by_key(&(location.offset as usize), |x| x.0)
+                        {
+                            Ok(x) => x,
+                            Err(x) => x.saturating_sub(1),
+                        };
+                        abort!(spans[pos].1, "Wgsl Error: {}", e)
+                    }
+                    let e_str = e.to_string();
+                    quote! {compile_error!(#e_str)}
+                }
+            }
+        }
+        Err(e) => {
+            if let Some((span, _)) = e.labels().next() {
+                let location = span.location(&source);
+                let pos = match spans.binary_search_by_key(&(location.offset as usize), |x| x.0) {
+                    Ok(x) => x,
+                    Err(x) => x.saturating_sub(1),
+                };
+                abort!(spans[pos].1, "Wgsl Error: {}", e)
+            }
+            let e_str = e.to_string();
+            quote! {compile_error!(#e_str)}
+        }
+    }
+}

--- a/src/wgsl_export2.rs
+++ b/src/wgsl_export2.rs
@@ -1,0 +1,47 @@
+use proc_macro2::{Span, TokenStream, TokenTree};
+use proc_macro_error::abort;
+use quote::{format_ident, quote};
+
+pub fn wgsl_export2(attr: TokenStream, stream: TokenStream) -> TokenStream {
+    let Some(TokenTree::Ident(name)) = attr.into_iter().next() else {
+        abort!(Span::call_site(), "Expected #[wgsl_export(name)]");
+    };
+    let mut wgsl_macro_ident = false;
+    let mut exclamation_mark = false;
+    let sealed = format_ident!("__sealed_{}", name);
+    let mut paste = format_ident!("__wgsl_paste_{}", name);
+    paste.set_span(name.span());
+    for token in stream.clone() {
+        match token {
+            TokenTree::Ident(i) if i == "wgsl" => {
+                wgsl_macro_ident = true;
+                exclamation_mark = false;
+            }
+            TokenTree::Punct(p) if wgsl_macro_ident && p.as_char() == '!' => {
+                exclamation_mark = true;
+            }
+            TokenTree::Group(g) if wgsl_macro_ident && exclamation_mark => {
+                let source = g.stream();
+                return quote! {
+                    #[allow(non_snake_case)]
+                    mod #sealed {
+                        #[allow(non_snake_case)]
+                        #[doc(hidden)]
+                        #[macro_export]
+                        macro_rules! #paste {
+                            (wgsl!($($tt: tt)*)) => {
+                                ::wgsl_ln::__wgsl_paste!(#name {#source} $($tt)*)
+                            };
+                        }
+                    }
+                    #stream
+                };
+            }
+            _ => {
+                wgsl_macro_ident = false;
+                exclamation_mark = false;
+            }
+        }
+    }
+    abort!(Span::call_site(), "Expected wgsl! macro.");
+}


### PR DESCRIPTION
I did not change any of the code. All the tests pass and examples still run. Just split the lib.rs file into smaller chunks for improved readability.